### PR TITLE
[BE] fix CouponDetailsAPI url regexp

### DIFF
--- a/aa_stripe/api_urls.py
+++ b/aa_stripe/api_urls.py
@@ -5,7 +5,7 @@ from rest_framework.routers import DefaultRouter
 from aa_stripe.api import CouponDetailsAPI, CustomersAPI, WebhookAPI
 
 urlpatterns = [
-    url(r"^aa-stripe/coupons/(?P<coupon_id>[\w]+)$", CouponDetailsAPI.as_view(), name="stripe-coupon-details"),
+    url(r"^aa-stripe/coupons/(?P<coupon_id>.*)$", CouponDetailsAPI.as_view(), name="stripe-coupon-details"),
     url(r"^aa-stripe/customers$", CustomersAPI.as_view(), name="stripe-customers"),
     url(r"^aa-stripe/webhooks$", WebhookAPI.as_view(), name="stripe-webhooks")
 ]

--- a/tests/test_coupons.py
+++ b/tests/test_coupons.py
@@ -187,7 +187,7 @@ class TestCoupons(BaseTestCase):
 
     def test_details_api(self):
         # test accessing without authentication
-        url = reverse("stripe-coupon-details", kwargs={"coupon_id": "FAKE"})
+        url = reverse("stripe-coupon-details", kwargs={"coupon_id": "FAKE-COUPON"})
         response = self.client.get(url, format="json")
         self.assertEqual(response.status_code, 403)
 


### PR DESCRIPTION
The problem with 404 error was caused because of an invalid regexp