### PR TITLE
[adhoc] Handle exceptions when default_source is missing

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+##[0.14.0]
+### Changed
+- Handle exceptions when `default_source` is missing in refresh_customers cronjob
+
+
 ##[0.13.0]
 ### Added
 - optional metadata field for member identitifer `member_uuid`

--- a/aa_stripe/__init__.py
+++ b/aa_stripe/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 __title__ = "Ro Stripe"
-__version__ = "0.13.0"
+__version__ = "0.14.0"
 __author__ = "Remigiusz Dymecki"
 __license__ = "MIT"
 __copyright__ = "Copyright 2019 Ro"

--- a/aa_stripe/management/commands/refresh_customers.py
+++ b/aa_stripe/management/commands/refresh_customers.py
@@ -34,15 +34,18 @@ class Command(BaseCommand):
                 retry_count = 0
 
             for stripe_customer in response["data"]:
-                updated_count += StripeCustomer.objects.filter(stripe_customer_id=stripe_customer["id"]).update(
-                    sources=stripe_customer["sources"]["data"], default_source=stripe_customer["default_source"]
-                )
+                try:
+                    updated_count += StripeCustomer.objects.filter(stripe_customer_id=stripe_customer["id"]).update(
+                        sources=stripe_customer["sources"]["data"], default_source=stripe_customer["default_source"]
+                    )
+                except Exception as err:
+                    print(f"Error updating customer with id {stripe_customer['id']}: {err}")
 
             if not response["has_more"]:
                 break
 
             if verbose:
-                sys.stdout.write(".")  # indicate that the command did not hung up
+                sys.stdout.write(".")  # indicate that the command did not hang up
                 sys.stdout.flush()
             last_customer = response["data"][-1]
 

--- a/aa_stripe/settings.py
+++ b/aa_stripe/settings.py
@@ -52,7 +52,7 @@ stripe_settings = StripeSettingOutter(StripeSettings())
 
 
 def reload_api_settings(*args, **kwargs):
-    global stripe_settings
+    global stripe_settings  # noqa: F824
     if kwargs["setting"].startswith("STRIPE_"):
         stripe_settings.settings_inner = StripeSettings()
 


### PR DESCRIPTION
This PR wraps the call to update stripe customers in a `try/except` and prints when a failure occurs. We are seeing some failures in this job due to a constraint violation. 

```
django.db.utils.IntegrityError: null value in column "default_source" violates not-null constraint
```

It looks like there are some stripe customers missing a `default_source` value.  [When this happens it causes the entire cron job to error.](https://app.datadoghq.com/monitors/170653236?group=%40cron_name%3Arefresh_customers&from_ts=1746514656000&to_ts=1746515856000&event_id=8090859077297703644&link_source=monitor_notif)