### PR TITLE
[feat] support creating account with payment method

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+##[0.15.0]
+### Added
+- support for passing `payment_method` as stripe_js_response
+
 ##[0.14.0]
 ### Changed
 - Handle exceptions when `default_source` is missing in refresh_customers cronjob

--- a/aa_stripe/__init__.py
+++ b/aa_stripe/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 __title__ = "Ro Stripe"
-__version__ = "0.14.0"
+__version__ = "0.15.0"
 __author__ = "Remigiusz Dymecki"
 __license__ = "MIT"
 __copyright__ = "Copyright 2019 Ro"

--- a/aa_stripe/models.py
+++ b/aa_stripe/models.py
@@ -459,8 +459,7 @@ class StripeCharge(StripeBasicModel):
                 logger.warning("[AA Stripe] user has no local default source")
                 stripe_customer = stripe.Customer.retrieve(customer.stripe_customer_id)
                 if (
-                    stripe_customer.invoice_settings
-                    and stripe_customer.invoice_settings.default_payment_method
+                    stripe_customer.invoice_settings and stripe_customer.invoice_settings.default_payment_method
                 ):
                     logger.info("[AA Stripe] using invoice settings default payment method")
                     params["payment_method"] = (

--- a/aa_stripe/models.py
+++ b/aa_stripe/models.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 import logging
 from decimal import Decimal
+from enum import StrEnum
 from time import sleep
 
 import simplejson as json
@@ -30,6 +31,11 @@ logger = logging.getLogger("aa-stripe")
 
 # signals
 webhook_pre_parse = dispatch.Signal()
+
+
+class StripeObject(StrEnum):
+    TOKEN = "token"
+    PAYMENT_METHOD = "payment_method"
 
 
 class StripeBasicModel(models.Model):
@@ -62,7 +68,17 @@ class StripeCustomer(StripeBasicModel):
             description = "{user} id: {user.id}".format(user=self.user)
 
         stripe.api_key = stripe_settings.API_KEY
-        customer = stripe.Customer.create(source=self.stripe_js_response["id"], description=description)
+        stripe_response = self.stripe_js_response
+        if not stripe_response:
+            raise StripeMethodNotAllowed("StripeCustomer.stripe_js_response must be set before creating customer.")
+
+        args = {"description": description}
+        if stripe_response["object"] == StripeObject.PAYMENT_METHOD:
+            args["payment_method"] = stripe_response["id"]
+        else:
+            args["source"] = stripe_response["id"]
+
+        customer = stripe.Customer.create(**args)
         self.stripe_customer_id = customer["id"]
         self.stripe_response = customer
         self.sources = customer.sources.data

--- a/aa_stripe/models.py
+++ b/aa_stripe/models.py
@@ -76,26 +76,23 @@ class StripeCustomer(StripeBasicModel):
             customer = self._create_customer_with_payment_method(stripe, description, stripe_response["id"])
         else:
             customer = stripe.Customer.create(
-                description=description,
-                source=stripe_response["id"]
+                description=description, source=stripe_response["id"]
             )
 
         self.stripe_customer_id = customer["id"]
         self.stripe_response = customer
         self.sources = customer.sources.data
-        self.default_source = customer.default_source
+        self.default_source = customer.default_source or ""
         self.is_created_at_stripe = True
         self.save()
         return self
 
     def _create_customer_with_payment_method(self, stripe, description, payment_method):
-        customer = stripe.Customer.create(
+        return stripe.Customer.create(
             description=description,
             payment_method=payment_method,
+            invoice_settings={"default_payment_method": payment_method},
         )
-        customer = stripe.Customer.modify(customer["id"], default_source=payment_method)
-
-        return customer
 
     @classmethod
     def get_latest_active_customer_for_user(cls, user):
@@ -457,6 +454,18 @@ class StripeCharge(StripeBasicModel):
             if self.statement_descriptor:
                 params["statement_descriptor"] = self.statement_descriptor
 
+            # payment method, will not be automatically picked up
+            if not customer.default_source:
+                logger.warning("[AA Stripe] user has no local default source")
+                stripe_customer = stripe.Customer.retrieve(customer.stripe_customer_id)
+                if (
+                    stripe_customer.invoice_settings
+                    and stripe_customer.invoice_settings.default_payment_method
+                ):
+                    logger.info("[AA Stripe] using invoice settings default payment method")
+                    params["payment_method"] = (
+                        stripe_customer.invoice_settings.default_payment_method
+                    )
             try:
                 stripe_charge = stripe.Charge.create(idempotency_key=idempotency_key, **params)
             except stripe.error.CardError as e:

--- a/aa_stripe/models.py
+++ b/aa_stripe/models.py
@@ -72,13 +72,14 @@ class StripeCustomer(StripeBasicModel):
         if not stripe_response:
             raise StripeMethodNotAllowed("StripeCustomer.stripe_js_response must be set before creating customer.")
 
-        args = {"description": description}
         if stripe_response["object"] == StripeObject.PAYMENT_METHOD:
-            args["payment_method"] = stripe_response["id"]
+            customer = self._create_customer_with_payment_method(stripe, description, stripe_response["id"])
         else:
-            args["source"] = stripe_response["id"]
+            customer = stripe.Customer.create(
+                description=description,
+                source=stripe_response["id"]
+            )
 
-        customer = stripe.Customer.create(**args)
         self.stripe_customer_id = customer["id"]
         self.stripe_response = customer
         self.sources = customer.sources.data
@@ -86,6 +87,15 @@ class StripeCustomer(StripeBasicModel):
         self.is_created_at_stripe = True
         self.save()
         return self
+
+    def _create_customer_with_payment_method(self, stripe, description, payment_method):
+        customer = stripe.Customer.create(
+            description=description,
+            payment_method=payment_method,
+        )
+        customer = stripe.Customer.modify(customer["id"], default_source=payment_method)
+
+        return customer
 
     @classmethod
     def get_latest_active_customer_for_user(cls, user):

--- a/aa_stripe/models.py
+++ b/aa_stripe/models.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 import logging
 from decimal import Decimal
-from enum import StrEnum
+from enum import Enum
 from time import sleep
 
 import simplejson as json
@@ -33,7 +33,7 @@ logger = logging.getLogger("aa-stripe")
 webhook_pre_parse = dispatch.Signal()
 
 
-class StripeObject(StrEnum):
+class StripeObject(str, Enum):
     TOKEN = "token"
     PAYMENT_METHOD = "payment_method"
 

--- a/tests/test_charge.py
+++ b/tests/test_charge.py
@@ -63,6 +63,7 @@ class TestCharges(TestCase):
             user=self.user,
             stripe_customer_id=self.data["customer_id"],
             stripe_js_response='"foo"',
+            default_source="card_1F5C7LBszOVoiLmg4k3b2eKX",
         )
         self.charge = StripeCharge.objects.create(
             user=self.user,

--- a/tests/test_customers.py
+++ b/tests/test_customers.py
@@ -11,49 +11,94 @@ from tests.test_utils import BaseTestCase
 
 UserModel = get_user_model()
 
+TOKEN_RESPONSE = {
+    "id": "tok_1RtAy3BszOVoiLmgtnBTx33m",
+    "object": "token",
+    "card": {
+        "id": "card_1RtAy3BszOVoiLmgqyW058jV",
+        "object": "card",
+        "address_city": None,
+        "address_country": None,
+        "address_line1": None,
+        "address_line1_check": None,
+        "address_line2": None,
+        "address_state": None,
+        "address_zip": "42424",
+        "address_zip_check": "unchecked",
+        "brand": "Visa",
+        "country": "US",
+        "cvc_check": "unchecked",
+        "dynamic_last4": None,
+        "exp_month": 12,
+        "exp_year": 2028,
+        "funding": "credit",
+        "last4": "4242",
+        "name": None,
+        "networks": {"preferred": None},
+        "regulated_status": "unregulated",
+        "tokenization_method": None,
+        "wallet": None,
+    },
+    "client_ip": "0.0.0.0",
+    "created": 1754500655,
+    "livemode": False,
+    "type": "card",
+    "used": False,
+}
+PAYMENT_METHOD_RESPONSE = {
+    "id": "pm_1Q0PsIJvEtkwdCNYMSaVuRz6",
+    "object": "payment_method",
+    "allow_redisplay": "unspecified",
+    "billing_details": {
+        "address": {
+            "city": None,
+            "country": None,
+            "line1": None,
+            "line2": None,
+            "postal_code": None,
+            "state": None,
+        },
+        "email": None,
+        "name": "John Doe",
+        "phone": None,
+    },
+    "created": 1726673582,
+    "customer": None,
+    "livemode": False,
+    "metadata": {},
+    "type": "us_bank_account",
+    "us_bank_account": {
+        "account_holder_type": "individual",
+        "account_type": "checking",
+        "bank_name": "STRIPE TEST BANK",
+        "financial_connections_account": None,
+        "fingerprint": "LstWJFsCK7P349Bg",
+        "last4": "6789",
+        "networks": {"preferred": "ach", "supported": ["ach"]},
+        "routing_number": "110000000",
+        "status_details": {},
+    },
+}
+
 
 class TestCreatingUsers(BaseTestCase):
     def setUp(self):
         self.user = self._create_user()
-        self.stripe_js_response = {
-            "id": "tok_193mTaHSTEMJ0IPXhhZ5vuTX",
-            "object": "customer",
-            "client_ip": None,
-            "created": 1476277734,
-            "livemode": False,
-            "type": "card",
-            "used": False,
-            "card": {
-                "id": "card_193mTaHSTEMJ0IPXIoOiuOdF",
-                "object": "card",
-                "address_city": None,
-                "address_country": None,
-                "address_line1": None,
-                "address_line1_check": None,
-                "address_line2": None,
-                "address_state": None,
-                "address_zip": None,
-                "address_zip_check": None,
-                "brand": "Visa",
-                "country": "US",
-                "cvc_check": None,
-                "dynamic_last4": None,
-                "exp_month": 8,
-                "exp_year": 2017,
-                "funding": "credit",
-                "last4": "4242",
-                "name": None,
-                "customerization_method": None,
-                "metadata": {},
-            },
-        }
 
-    def test_user_create(self):
+    def test_user_create_with_token(self):
+        stripe_js_response = TOKEN_RESPONSE
+        self._test_user_create(stripe_js_response)
+
+    def test_user_create_with_payment_method(self):
+        stripe_js_response = PAYMENT_METHOD_RESPONSE
+        self._test_user_create(stripe_js_response)
+
+    def _test_user_create(self, stripe_js_response):
         self.assertEqual(StripeCustomer.objects.count(), 0)
         url = reverse("stripe-customers")
 
-        data = {}
-        response = self.client.post(url, format="json")
+        data = {"stripe_js_response": stripe_js_response}
+        response = self.client.post(url, data, format="json")
         self.assertEqual(response.status_code, 403)  # not logged
 
         self.client.force_authenticate(user=self.user)
@@ -116,8 +161,10 @@ class TestCreatingUsers(BaseTestCase):
             )
 
             # test response error
-            stripe_customer_qs = StripeCustomer.objects.filter(is_created_at_stripe=True)
-            data = {"stripe_js_response": self.stripe_js_response}
+            stripe_customer_qs = StripeCustomer.objects.filter(
+                is_created_at_stripe=True
+            )
+            data = {"stripe_js_response": stripe_js_response}
             self.client.force_authenticate(user=self.user)
             response = self.client.post(url, data, format="json")
             self.assertEqual(response.status_code, 400)
@@ -134,19 +181,20 @@ class TestCreatingUsers(BaseTestCase):
             customer = stripe_customer_qs.first()
             self.assertTrue(customer.is_active)
             self.assertEqual(customer.user, self.user)
-            self.assertEqual(customer.stripe_js_response, self.stripe_js_response)
+            self.assertEqual(customer.stripe_js_response, stripe_js_response)
             self.assertEqual(customer.stripe_customer_id, "cus_9Oop0gQ1R1ATMi")
             self.assertEqual(customer.stripe_response["id"], "cus_9Oop0gQ1R1ATMi")
             self.assertEqual(customer.sources, [{"id": "card_xyz", "object": "card"}])
             self.assertEqual(customer.default_source, "card_xyz")
 
     def test_change_description(self):
-        customer_id = self.stripe_js_response["id"]
+        stripe_js_response = TOKEN_RESPONSE
+        customer_id = stripe_js_response["id"]
         customer = StripeCustomer(user=self.user, stripe_customer_id=customer_id)
         api_url = "https://api.stripe.com/v1/customers/{customer_id}".format(customer_id=customer_id)
         with requests_mock.Mocker() as m:
-            m.register_uri("GET", api_url, text=json.dumps(self.stripe_js_response))
-            m.register_uri("POST", api_url, text=json.dumps(self.stripe_js_response))
+            m.register_uri("GET", api_url, text=json.dumps(stripe_js_response))
+            m.register_uri("POST", api_url, text=json.dumps(stripe_js_response))
             customer.change_description("abc")
 
 

--- a/tests/test_customers.py
+++ b/tests/test_customers.py
@@ -105,6 +105,35 @@ class TestCreatingUsers(BaseTestCase):
         response = self.client.post(url, format="json")
         self.assertEqual(response.status_code, 400)
 
+        stripe_customer_rs = {
+            "id": "cus_9Oop0gQ1R1ATMi",
+            "object": "customer",
+            "account_balance": 0,
+            "created": 1476810921,
+            "currency": "usd",
+            "default_source": "card_xyz",
+            "delinquent": False,
+            "description": None,
+            "discount": None,
+            "email": None,
+            "livemode": False,
+            "metadata": {},
+            "shipping": None,
+            "sources": {
+                "object": "list",
+                "data": [{"id": "card_xyz", "object": "card"}],
+                "has_more": False,
+                "total_count": 1,
+                "url": "/v1/customers/cus_9Oop0gQ1R1ATMi/sources",
+            },
+            "subscriptions": {
+                "object": "list",
+                "data": [],
+                "has_more": False,
+                "total_count": 0,
+                "url": "/v1/customers/cus_9Oop0gQ1R1ATMi/subscriptions",
+            },
+        }
         with requests_mock.Mocker() as m:
             m.register_uri(
                 "POST",
@@ -124,42 +153,14 @@ class TestCreatingUsers(BaseTestCase):
                         ),
                         "status_code": 400,
                     },
-                    {
-                        "text": json.dumps(
-                            {
-                                "id": "cus_9Oop0gQ1R1ATMi",
-                                "object": "customer",
-                                "account_balance": 0,
-                                "created": 1476810921,
-                                "currency": "usd",
-                                "default_source": "card_xyz",
-                                "delinquent": False,
-                                "description": None,
-                                "discount": None,
-                                "email": None,
-                                "livemode": False,
-                                "metadata": {},
-                                "shipping": None,
-                                "sources": {
-                                    "object": "list",
-                                    "data": [{"id": "card_xyz", "object": "card"}],
-                                    "has_more": False,
-                                    "total_count": 1,
-                                    "url": "/v1/customers/cus_9Oop0gQ1R1ATMi/sources",
-                                },
-                                "subscriptions": {
-                                    "object": "list",
-                                    "data": [],
-                                    "has_more": False,
-                                    "total_count": 0,
-                                    "url": "/v1/customers/cus_9Oop0gQ1R1ATMi/subscriptions",
-                                },
-                            }
-                        )
-                    },
+                    {"text": json.dumps(stripe_customer_rs)},
                 ],
             )
-
+            m.register_uri(
+                "POST",
+                "https://api.stripe.com/v1/customers/cus_9Oop0gQ1R1ATMi",
+                text=json.dumps(stripe_customer_rs),
+            )
             # test response error
             stripe_customer_qs = StripeCustomer.objects.filter(
                 is_created_at_stripe=True
@@ -176,7 +177,6 @@ class TestCreatingUsers(BaseTestCase):
             # test success response from Stripe
             response = self.client.post(url, data, format="json")
             self.assertEqual(response.status_code, 201)
-            self.assertEqual(m.call_count, 2)
             self.assertEqual(stripe_customer_qs.count(), 1)
             customer = stripe_customer_qs.first()
             self.assertTrue(customer.is_active)


### PR DESCRIPTION
update create customer in stripe to add an option where an already created payment method is passed and used when creating customer. 
supports offline OV